### PR TITLE
Change to strict arity

### DIFF
--- a/Sources/Array.swift
+++ b/Sources/Array.swift
@@ -9,45 +9,41 @@
 public extension Array {
 
     @discardableResult
-    func combination(_ length:Int? = nil) -> [[Element]] {
-        let _len = length ?? self.count
-        if _len > self.count || _len < 0 { return [] }
-        if _len == 0 { return [[]] }
+    func combination(_ length:Int) -> [[Element]] {
+        if length > self.count || length < 0 { return [] }
+        if length == 0 { return [[]] }
 
         var ret = [[Element]]()
-        _combination(self, length: _len){ ret.append($0) }
+        _combination(self, length: length){ ret.append($0) }
 
         return ret
     }
 
     @discardableResult
-    func combination(_ length:Int? = nil, process:([Element]) -> ()) -> [Element] {
-        let _len = length ?? self.count
-        if _len > self.count || _len < 0 { return [] }
-        if _len == 0 { process([]); return self }
+    func combination(_ length:Int, process:([Element]) -> ()) -> [Element] {
+        if length > self.count || length < 0 { return [] }
+        if length == 0 { process([]); return self }
 
-        return _combination(self, length: _len, process: process)
+        return _combination(self, length: length, process: process)
     }
 
     @discardableResult
-    func repeatedCombination(_ length:Int? = nil) -> [[Element]] {
-        let _len = length ?? self.count
-        if _len < 0 { return [] }
-        if _len == 0 { return [[]] }
+    func repeatedCombination(_ length:Int) -> [[Element]] {
+        if length < 0 { return [] }
+        if length == 0 { return [[]] }
 
         var ret = [[Element]]()
-        _repeatedCombination(self, length: _len){ ret.append($0) }
+        _repeatedCombination(self, length: length){ ret.append($0) }
 
         return ret
     }
 
     @discardableResult
-    func repeatedCombination(_ length:Int? = nil, process:([Element]) -> ()) -> [Element] {
-        let _len = length ?? self.count
-        if _len < 0 { return [] }
-        if _len == 0 { process([]); return self }
+    func repeatedCombination(_ length:Int, process:([Element]) -> ()) -> [Element] {
+        if length < 0 { return [] }
+        if length == 0 { process([]); return self }
 
-        return _repeatedCombination(self, length: _len, process: process)
+        return _repeatedCombination(self, length: length, process: process)
     }
 
     @discardableResult
@@ -67,29 +63,27 @@ public extension Array {
         let _len = length ?? self.count
         if _len > self.count || _len < 0 { return [] }
         if _len == 0 { process([]); return self }
-        
+
         return _permutation(self, length: _len, process: process)
     }
 
     @discardableResult
-    func repeatedPermutation(_ length:Int? = nil) -> [[Element]] {
-        let _len = length ?? self.count
-        if _len < 0 { return [] }
-        if _len == 0 { return [[]] }
+    func repeatedPermutation(_ length:Int) -> [[Element]] {
+        if length < 0 { return [] }
+        if length == 0 { return [[]] }
 
         var ret = [[Element]]()
-        _repeatedPermutation(self, length: _len){ ret.append($0) }
+        _repeatedPermutation(self, length: length){ ret.append($0) }
 
         return ret
     }
 
     @discardableResult
-    func repeatedPermutation(_ length:Int? = nil, process:([Element]) -> ()) -> [Element] {
-        let _len = length ?? self.count
-        if _len < 0 { return [] }
-        if _len == 0 { process([]); return self }
+    func repeatedPermutation(_ length:Int, process:([Element]) -> ()) -> [Element] {
+        if length < 0 { return [] }
+        if length == 0 { process([]); return self }
 
-        return _repeatedPermutation(self, length: _len, process: process)
+        return _repeatedPermutation(self, length: length, process: process)
     }
 
 }

--- a/Sources/functions.swift
+++ b/Sources/functions.swift
@@ -7,72 +7,66 @@
 //
 
 @discardableResult
-public func combination<T>(_ arr:[T], length:Int? = nil) -> [[T]] {
-    let _len = length ?? arr.count
-    if _len > arr.count || _len < 0 { return [] }
+public func combination<T>(_ arr:[T], length:Int) -> [[T]] {
+    if length > arr.count || length < 0 { return [] }
     if arr.isEmpty { return [] }
-    if _len == 0 { return [[]] }
+    if length == 0 { return [[]] }
 
     var ret = [[T]]()
-    _combination(arr, length: _len){ ret.append($0) }
+    _combination(arr, length: length){ ret.append($0) }
 
     return ret
 }
 
 @discardableResult
-public func combination<T>(_ arr:[T], length:Int? = nil, process:([T]) -> ()) -> [T] {
-    let _len = length ?? arr.count
-    if _len > arr.count || _len < 0 { return [] }
+public func combination<T>(_ arr:[T], length:Int, process:([T]) -> ()) -> [T] {
+    if length > arr.count || length < 0 { return [] }
     if arr.isEmpty { return [] }
-    if _len == 0 { process([]); return arr }
+    if length == 0 { process([]); return arr }
 
-    return _combination(arr, length: _len, process: process)
+    return _combination(arr, length: length, process: process)
 }
 
 @discardableResult
-public func repeatedCombination<T>(_ arr:[T], length:Int? = nil) -> [[T]] {
-    let _len = length ?? arr.count
-    if _len < 0 { return [] }
+public func repeatedCombination<T>(_ arr:[T], length:Int) -> [[T]] {
+    if length < 0 { return [] }
     if arr.isEmpty { return [] }
-    if _len == 0 { return [[]] }
+    if length == 0 { return [[]] }
 
     var ret = [[T]]()
-    _repeatedCombination(arr, length: _len){ ret.append($0) }
+    _repeatedCombination(arr, length: length){ ret.append($0) }
 
     return ret
 }
 
 @discardableResult
-public func repeatedCombination<T>(_ arr:[T], length:Int? = nil, process:([T]) -> ()) -> [T] {
-    let _len = length ?? arr.count
-    if _len < 0 { return [] }
+public func repeatedCombination<T>(_ arr:[T], length:Int, process:([T]) -> ()) -> [T] {
+    if length < 0 { return [] }
     if arr.isEmpty { return [] }
-    if _len == 0 { process([]); return arr }
+    if length == 0 { process([]); return arr }
 
-    return _repeatedCombination(arr, length: _len, process: process)
+    return _repeatedCombination(arr, length: length, process: process)
 }
 
 @discardableResult
-public func repeatedPermutation<T>(_ arr:[T], length:Int? = nil) -> [[T]] {
-    let _len = length ?? arr.count
-    if _len < 0 { return [] }
+public func repeatedPermutation<T>(_ arr:[T], length:Int) -> [[T]] {
+    if length < 0 { return [] }
     if arr.isEmpty { return [] }
-    if _len == 0 { return [[]] }
+    if length == 0 { return [[]] }
 
     var ret = [[T]]()
-    _repeatedPermutation(arr, length: _len){ ret.append($0) }
+    _repeatedPermutation(arr, length: length){ ret.append($0) }
 
     return ret
 }
 
 @discardableResult
-public func repeatedPermutation<T>(_ arr:[T], length:Int? = nil, process:([T]) -> ()) -> [T] {
-    let _len = length ?? arr.count
-    if _len < 0 { return [] }
+public func repeatedPermutation<T>(_ arr:[T], length:Int, process:([T]) -> ()) -> [T] {
+    if length < 0 { return [] }
     if arr.isEmpty { return [] }
-    if _len == 0 { process([]); return arr }
+    if length == 0 { process([]); return arr }
 
-    return _repeatedPermutation(arr, length: _len, process: process)
+    return _repeatedPermutation(arr, length: length, process: process)
 }
 
 @discardableResult

--- a/Tests/SwiftCombinationTests/ArrayExtensionTests/ArrayCombinationTests.swift
+++ b/Tests/SwiftCombinationTests/ArrayExtensionTests/ArrayCombinationTests.swift
@@ -11,13 +11,6 @@ import SwiftCombination
 final class ArrayCombinationTests: SwiftCombinationTests {}
 
 extension ArrayCombinationTests {
-    func testImplicitLength() {
-        let actual = [0, 1, 2].combination()
-        let expected = [[0, 1, 2]]
-        XCTAssertEqual(actual.count, expected.count)
-        zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
     func testExplicitLength() {
         let actual = [0, 1, 2].combination(3)
         let expected = [[0, 1, 2]]
@@ -35,16 +28,6 @@ extension ArrayCombinationTests {
     func testArgLengthGreaterThanCollectionLength() {
         let actual = [0, 1, 2].combination(4)
         XCTAssertTrue(actual.isEmpty)
-    }
-
-    func testImplicitLengthWithClosure() {
-        let expected = [[0, 1, 2]]
-        var i = 0
-        [0, 1, 2].combination{ actual in
-            XCTAssertEqual(actual, expected[i])
-            i = i + 1
-        }
-        XCTAssertNotEqual(i, 0)
     }
 
     func testExplicitLengthWithClosure() {
@@ -74,11 +57,9 @@ extension ArrayCombinationTests {
     }
 
     static var allTests = [
-        ("testImplicitLength", testImplicitLength),
         ("testExplicitLength", testExplicitLength),
         ("testArgLengthLessThanCollectionLength", testArgLengthLessThanCollectionLength),
         ("testArgLengthGreaterThanCollectionLength", testArgLengthGreaterThanCollectionLength),
-        ("testImplicitLengthWithClosure", testImplicitLengthWithClosure),
         ("testExplicitLengthWithClosure", testExplicitLengthWithClosure),
         ("testArgLengthLessThanCollectionLengthWithClosure", testArgLengthLessThanCollectionLengthWithClosure),
         ("testArgLengthGreaterThanCollectionLengthWithClosure", testArgLengthGreaterThanCollectionLengthWithClosure),

--- a/Tests/SwiftCombinationTests/ArrayExtensionTests/ArrayRepeatedCombinationTests.swift
+++ b/Tests/SwiftCombinationTests/ArrayExtensionTests/ArrayRepeatedCombinationTests.swift
@@ -11,13 +11,6 @@ import SwiftCombination
 final class ArrayRepeatedCombinationTests: SwiftCombinationTests {}
 
 extension ArrayRepeatedCombinationTests {
-    func testImplicitLength() {
-        let actual = [0, 1].repeatedCombination()
-        let expected = [[0, 0], [0, 1], [1, 1]]
-        XCTAssertEqual(actual.count, expected.count)
-        zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
     func testExplicitLength() {
         let actual = [0, 1].repeatedCombination(2)
         let expected = [[0, 0], [0, 1], [1, 1]]
@@ -42,16 +35,6 @@ extension ArrayRepeatedCombinationTests {
         ]
         XCTAssertEqual(actual.count, expected.count)
         zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
-    func testImplicitLengthWithClosure() {
-        let expected = [[0, 0], [0, 1], [1, 1]]
-        var i = 0
-        [0, 1].repeatedCombination{ actual in
-            XCTAssertEqual(actual, expected[i])
-            i = i + 1
-        }
-        XCTAssertNotEqual(i, 0)
     }
 
     func testExplicitLengthWithClosure() {
@@ -90,11 +73,9 @@ extension ArrayRepeatedCombinationTests {
     }
 
     static var allTests = [
-        ("testImplicitLength", testImplicitLength),
         ("testExplicitLength", testExplicitLength),
         ("testArgLengthLessThanCollectionLength", testArgLengthLessThanCollectionLength),
         ("testArgLengthGreaterThanCollectionLength", testArgLengthGreaterThanCollectionLength),
-        ("testImplicitLengthWithClosure", testImplicitLengthWithClosure),
         ("testExplicitLengthWithClosure", testExplicitLengthWithClosure),
         ("testArgLengthLessThanCollectionLengthWithClosure", testArgLengthLessThanCollectionLengthWithClosure),
         ("testArgLengthGreaterThanCollectionLengthWithClosure", testArgLengthGreaterThanCollectionLengthWithClosure),

--- a/Tests/SwiftCombinationTests/ArrayExtensionTests/ArrayRepeatedPermutationTests.swift
+++ b/Tests/SwiftCombinationTests/ArrayExtensionTests/ArrayRepeatedPermutationTests.swift
@@ -11,13 +11,6 @@ import SwiftCombination
 final class ArrayRepeatedPermutationTests: SwiftCombinationTests {}
 
 extension ArrayRepeatedPermutationTests {
-    func testImplicitLength() {
-        let actual = [0, 1].repeatedPermutation()
-        let expected = [[0, 0], [0, 1], [1, 0], [1, 1]]
-        XCTAssertEqual(actual.count, expected.count)
-        zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
     func testExplicitLength() {
         let actual = [0, 1].repeatedPermutation(2)
         let expected = [[0, 0], [0, 1], [1, 0], [1, 1]]
@@ -46,16 +39,6 @@ extension ArrayRepeatedPermutationTests {
         ]
         XCTAssertEqual(actual.count, expected.count)
         zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
-    func testImplicitLengthWithClosure() {
-        let expected = [[0, 0], [0, 1], [1, 0], [1, 1]]
-        var i = 0
-        [0, 1].repeatedPermutation{ actual in
-            XCTAssertEqual(actual, expected[i])
-            i = i + 1
-        }
-        XCTAssertNotEqual(i, 0)
     }
 
     func testExplicitLengthWithClosure() {
@@ -98,11 +81,9 @@ extension ArrayRepeatedPermutationTests {
     }
 
     static var allTests = [
-        ("testImplicitLength", testImplicitLength),
         ("testExplicitLength", testExplicitLength),
         ("testArgLengthLessThanCollectionLength", testArgLengthLessThanCollectionLength),
         ("testArgLengthGreaterThanCollectionLength", testArgLengthGreaterThanCollectionLength),
-        ("testImplicitLengthWithClosure", testImplicitLengthWithClosure),
         ("testExplicitLengthWithClosure", testExplicitLengthWithClosure),
         ("testArgLengthLessThanCollectionLengthWithClosure", testArgLengthLessThanCollectionLengthWithClosure),
         ("testArgLengthGreaterThanCollectionLengthWithClosure", testArgLengthGreaterThanCollectionLengthWithClosure),

--- a/Tests/SwiftCombinationTests/GlobalFunctionTests/GlobalCombinationTests.swift
+++ b/Tests/SwiftCombinationTests/GlobalFunctionTests/GlobalCombinationTests.swift
@@ -11,13 +11,6 @@ import SwiftCombination
 final class GlobalCombinationTests: SwiftCombinationTests {}
 
 extension GlobalCombinationTests {
-    func testImplicitLength() {
-        let actual = combination([0, 1, 2])
-        let expected = [[0, 1, 2]]
-        XCTAssertEqual(actual.count, expected.count)
-        zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
     func testExplicitLength() {
         let actual = combination([0, 1, 2], length: 3)
         let expected = [[0, 1, 2]]
@@ -35,16 +28,6 @@ extension GlobalCombinationTests {
     func testArgLengthGreaterThanCollectionLength() {
         let actual = combination([0, 1, 2], length: 4)
         XCTAssertTrue(actual.isEmpty)
-    }
-
-    func testImplicitLengthWithClosure() {
-        let expected = [[0, 1, 2]]
-        var i = 0
-        combination([0, 1, 2]) { actual in
-            XCTAssertEqual(actual, expected[i])
-            i = i + 1
-        }
-        XCTAssertNotEqual(i, 0)
     }
 
     func testExplicitLengthWithClosure() {
@@ -74,11 +57,9 @@ extension GlobalCombinationTests {
     }
 
     static var allTests = [
-        ("testImplicitLength", testImplicitLength),
         ("testExplicitLength", testExplicitLength),
         ("testArgLengthLessThanCollectionLength", testArgLengthLessThanCollectionLength),
         ("testArgLengthGreaterThanCollectionLength", testArgLengthGreaterThanCollectionLength),
-        ("testImplicitLengthWithClosure", testImplicitLengthWithClosure),
         ("testExplicitLengthWithClosure", testExplicitLengthWithClosure),
         ("testArgLengthLessThanCollectionLengthWithClosure", testArgLengthLessThanCollectionLengthWithClosure),
         ("testArgLengthGreaterThanCollectionLengthWithClosure", testArgLengthGreaterThanCollectionLengthWithClosure),

--- a/Tests/SwiftCombinationTests/GlobalFunctionTests/GlobalRepeatedCombinationTests.swift
+++ b/Tests/SwiftCombinationTests/GlobalFunctionTests/GlobalRepeatedCombinationTests.swift
@@ -11,13 +11,6 @@ import SwiftCombination
 final class GlobalRepeatedCombinationTests: SwiftCombinationTests {}
 
 extension GlobalRepeatedCombinationTests {
-    func testImplicitLength() {
-        let actual = repeatedCombination([0, 1])
-        let expected = [[0, 0], [0, 1], [1, 1]]
-        XCTAssertEqual(actual.count, expected.count)
-        zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
     func testExplicitLength() {
         let actual = repeatedCombination([0, 1], length: 2)
         let expected = [[0, 0], [0, 1], [1, 1]]
@@ -42,16 +35,6 @@ extension GlobalRepeatedCombinationTests {
         ]
         XCTAssertEqual(actual.count, expected.count)
         zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
-    func testImplicitLengthWithClosure() {
-        let expected = [[0, 0], [0, 1], [1, 1]]
-        var i = 0
-        repeatedCombination([0, 1]) { actual in
-            XCTAssertEqual(actual, expected[i])
-            i = i + 1
-        }
-        XCTAssertNotEqual(i, 0)
     }
 
     func testExplicitLengthWithClosure() {
@@ -90,11 +73,9 @@ extension GlobalRepeatedCombinationTests {
     }
 
     static var allTests = [
-        ("testImplicitLength", testImplicitLength),
         ("testExplicitLength", testExplicitLength),
         ("testArgLengthLessThanCollectionLength", testArgLengthLessThanCollectionLength),
         ("testArgLengthGreaterThanCollectionLength", testArgLengthGreaterThanCollectionLength),
-        ("testImplicitLengthWithClosure", testImplicitLengthWithClosure),
         ("testExplicitLengthWithClosure", testExplicitLengthWithClosure),
         ("testArgLengthLessThanCollectionLengthWithClosure", testArgLengthLessThanCollectionLengthWithClosure),
         ("testArgLengthGreaterThanCollectionLengthWithClosure", testArgLengthGreaterThanCollectionLengthWithClosure),

--- a/Tests/SwiftCombinationTests/GlobalFunctionTests/GlobalRepeatedPermutationTests.swift
+++ b/Tests/SwiftCombinationTests/GlobalFunctionTests/GlobalRepeatedPermutationTests.swift
@@ -11,13 +11,6 @@ import SwiftCombination
 final class GlobalRepeatedPermutationTests: SwiftCombinationTests {}
 
 extension GlobalRepeatedPermutationTests {
-    func testImplicitLength() {
-        let actual = repeatedPermutation([0, 1])
-        let expected = [[0, 0], [0, 1], [1, 0], [1, 1]]
-        XCTAssertEqual(actual.count, expected.count)
-        zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
     func testExplicitLength() {
         let actual = repeatedPermutation([0, 1], length: 2)
         let expected = [[0, 0], [0, 1], [1, 0], [1, 1]]
@@ -48,16 +41,6 @@ extension GlobalRepeatedPermutationTests {
 
         XCTAssertEqual(actual.count, expected.count)
         zip(actual, expected).forEach { XCTAssertEqual($0, $1) }
-    }
-
-    func testImplicitLengthWithClosure() {
-        let expected = [[0, 0], [0, 1], [1, 0], [1, 1]]
-        var i = 0
-        repeatedPermutation([0, 1]) { actual in
-            XCTAssertEqual(actual, expected[i])
-            i = i + 1
-        }
-        XCTAssertNotEqual(i, 0)
     }
 
     func testExplicitLengthWithClosure() {
@@ -100,11 +83,9 @@ extension GlobalRepeatedPermutationTests {
     }
 
     static var allTests = [
-        ("testImplicitLength", testImplicitLength),
         ("testExplicitLength", testExplicitLength),
         ("testArgLengthLessThanCollectionLength", testArgLengthLessThanCollectionLength),
         ("testArgLengthGreaterThanCollectionLength", testArgLengthGreaterThanCollectionLength),
-        ("testImplicitLengthWithClosure", testImplicitLengthWithClosure),
         ("testExplicitLengthWithClosure", testExplicitLengthWithClosure),
         ("testArgLengthLessThanCollectionLengthWithClosure", testArgLengthLessThanCollectionLengthWithClosure),
         ("testArgLengthGreaterThanCollectionLengthWithClosure", testArgLengthGreaterThanCollectionLengthWithClosure),


### PR DESCRIPTION
Deny calling to `combination`, `repeatedCombination`, `repeatedPermutation` with implicit length argument.

```swift
// before
[0, 1, 2].combination()
// => [[0, 1, 2]]

// after
[0, 1, 2].combination() // Cannot invoke 'combination' with no arguments
[0, 1, 2].combination(3)
// => [[0, 1, 2]]
```
